### PR TITLE
Touch all fields that have errors

### DIFF
--- a/src/useWizard.ts
+++ b/src/useWizard.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import { setNestedObjectValues } from 'formik';
 import { Step } from './types';
 import { isFunction } from './utils';
 
@@ -48,6 +49,7 @@ const useWizard = (
 
       if (validateOnNext) {
         const errors = await formikBag.validateForm();
+        formikBag.setTouched(setNestedObjectValues(errors, true));
         isValid = Object.keys(errors).length === 0;
       }
 


### PR DESCRIPTION
When a person doesn't touch all the fields before hitting next. You don't see any error messages unless you touch the field after the form is validated. 

See comment on formik here: https://github.com/jaredpalmer/formik/issues/2734#issuecomment-923337541